### PR TITLE
Create zh_cn.json

### DIFF
--- a/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
+++ b/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
@@ -1,0 +1,33 @@
+{
+  "text.autoconfig.compactstatuseffects.title": "迷你状态效果配置",
+  
+  "text.autoconfig.compactstatuseffects.option.module": "状态效果显示的方式",
+  
+  "text.autoconfig.compactstatuseffects.option.boxedConfig": "BOXED 图标模式设置 (图标及具体时长)",
+  
+  "text.autoconfig.compactstatuseffects.option.boxedConfig.maxEffectsNumber": "每列能显示多少个状态效果",
+  "text.autoconfig.compactstatuseffects.option.boxedConfig.maxEffectsNumber.@Tooltip": "在转到下一列前能显示多少个状态效果",
+  
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig": "ONLYNAME 仅名称模式设置 (仅名称)",
+  
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.maxEffectsNumber": "每列能显示多少个状态效果",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.maxEffectsNumber.@Tooltip": "在转到下一列前能显示多少个状态效果",
+  
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.permanentColour": "永久状态效果的颜色",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.wontExpireSoonColour": "时长充足的颜色",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireColour": "时长不足的颜色",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringColour": "即将消失的颜色",
+  
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringBound": "“即将消失” 的界限 (秒)",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringBound.@Tooltip[0]": "剩余时长小于这个数值的状态效果属于 “即将消失”, 大于这个数值的属于 “时长不足”",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringBound.@Tooltip[1]": "( “即将消失” < 设置的界限 < “时长不足” )",
+  
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound": "“时长不足” 的界限 (秒)",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound.@Tooltip[0]": "剩余时长小于这个数值的状态效果属于 “时长不足”, 大于这个数值的属于 “时长充足”",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound.@Tooltip[1]": "( “时长不足” < 设置的界限 < “时长充足” )",
+  
+  "text.autoconfig.compactstatuseffects.option.noSpriteConfig": "NOSPRITE 名称模式设置 (名称及具体时长)",
+  
+  "text.autoconfig.compactstatuseffects.option.noSpriteConfig.maxEffectsNumber": "每列能显示多少个状态效果",
+  "text.autoconfig.compactstatuseffects.option.noSpriteConfig.maxEffectsNumber.@Tooltip": "在转到下一列前能显示多少个状态效果"
+}

--- a/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
+++ b/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
@@ -19,12 +19,12 @@
   "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringColour": "即将消失的颜色",
   
   "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringBound": "“即将消失” 的界限 (秒)",
-  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringBound.@Tooltip[0]": "剩余时长小于这个数值的状态效果属于 “即将消失”, 大于这个数值的属于 “时长不足”",
-  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringBound.@Tooltip[1]": "( “即将消失” < 设置的界限 < “时长不足” )",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringBound.@Tooltip[0]": "“即将消失” < 此处设置的界限 < “时长不足”",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringBound.@Tooltip[1]": "( 剩余时长小于这个数值的状态效果属于 “即将消失”, 大于这个数值的属于 “时长不足” )",
   
   "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound": "“时长不足” 的界限 (秒)",
-  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound.@Tooltip[0]": "剩余时长小于这个数值的状态效果属于 “时长不足”, 大于这个数值的属于 “时长充足”",
-  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound.@Tooltip[1]": "( “时长不足” < 设置的界限 < “时长充足” )",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound.@Tooltip[0]": "“时长不足” < 此处设置的界限 < “时长充足”",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound.@Tooltip[1]": "( 剩余时长小于这个数值的状态效果属于 “时长不足”, 大于这个数值的属于 “时长充足” )",
   
   "text.autoconfig.compactstatuseffects.option.noSpriteConfig": "NOSPRITE 名称模式设置 (名称及具体时长)",
   

--- a/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
+++ b/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
@@ -2,16 +2,17 @@
   "text.autoconfig.compactstatuseffects.title": "迷你状态效果配置 (Compact Status Effects)",
   
   "text.autoconfig.compactstatuseffects.option.module": "状态效果的显示方式",
+  "text.autoconfig.compactstatuseffects.option.margin": "状态效果显示与 GUI 的间距",
   
-  "text.autoconfig.compactstatuseffects.option.boxedConfig": "BOXED 图标模式设置 (图标及具体时长)",
+  "text.autoconfig.compactstatuseffects.option.noNameConfig": "NONAME 无名称模式设置 (图标+具体时长)",
   
-  "text.autoconfig.compactstatuseffects.option.boxedConfig.maxEffectsNumber": "每列能显示多少个状态效果",
-  "text.autoconfig.compactstatuseffects.option.boxedConfig.maxEffectsNumber.@Tooltip": "在转到下一列前能显示多少个状态效果",
+  "text.autoconfig.compactstatuseffects.option.noNameConfig.maxEffectsNumber": "每列能显示多少个状态效果",
+  "text.autoconfig.compactstatuseffects.option.noNameConfig.maxEffectsNumber.@Tooltip": "在启用新一列前能显示多少个状态效果",
   
-  "text.autoconfig.compactstatuseffects.option.onlyNameConfig": "ONLYNAME 仅名称模式设置 (仅名称)",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig": "ONLYNAME 仅名称模式设置 (名称+粗略时长)",
   
   "text.autoconfig.compactstatuseffects.option.onlyNameConfig.maxEffectsNumber": "每列能显示多少个状态效果",
-  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.maxEffectsNumber.@Tooltip": "在转到下一列前能显示多少个状态效果",
+  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.maxEffectsNumber.@Tooltip": "在启用新一列前能显示多少个状态效果",
   
   "text.autoconfig.compactstatuseffects.option.onlyNameConfig.permanentColour": "永久状态效果的颜色",
   "text.autoconfig.compactstatuseffects.option.onlyNameConfig.wontExpireSoonColour": "时长充足的颜色",
@@ -26,8 +27,8 @@
   "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound.@Tooltip[0]": "“时长不足” < 此处设置的界限 < “时长充足”",
   "text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound.@Tooltip[1]": "( 剩余时长小于这个数值的状态效果属于 “时长不足”, 大于这个数值的属于 “时长充足” )",
   
-  "text.autoconfig.compactstatuseffects.option.noSpriteConfig": "NOSPRITE 名称模式设置 (名称及具体时长)",
+  "text.autoconfig.compactstatuseffects.option.noSpriteConfig": "NOSPRITE 无图标模式设置 (名称+具体时长)",
   
   "text.autoconfig.compactstatuseffects.option.noSpriteConfig.maxEffectsNumber": "每列能显示多少个状态效果",
-  "text.autoconfig.compactstatuseffects.option.noSpriteConfig.maxEffectsNumber.@Tooltip": "在转到下一列前能显示多少个状态效果"
+  "text.autoconfig.compactstatuseffects.option.noSpriteConfig.maxEffectsNumber.@Tooltip": "在启用新一列前能显示多少个状态效果"
 }

--- a/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
+++ b/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
@@ -1,5 +1,5 @@
 {
-  "text.autoconfig.compactstatuseffects.title": "迷你状态效果配置",
+  "text.autoconfig.compactstatuseffects.title": "迷你状态效果配置 (Compact Status Effects)",
   
   "text.autoconfig.compactstatuseffects.option.module": "状态效果的显示方式",
   

--- a/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
+++ b/src/main/resources/assets/compactstatuseffects/lang/zh_cn.json
@@ -1,7 +1,7 @@
 {
   "text.autoconfig.compactstatuseffects.title": "迷你状态效果配置",
   
-  "text.autoconfig.compactstatuseffects.option.module": "状态效果显示的方式",
+  "text.autoconfig.compactstatuseffects.option.module": "状态效果的显示方式",
   
   "text.autoconfig.compactstatuseffects.option.boxedConfig": "BOXED 图标模式设置 (图标及具体时长)",
   


### PR DESCRIPTION
Besides the request of Chinese translation, there's a little suggestion on the current config description: 
- For `  "text.autoconfig.compactstatuseffects.option.onlyNameConfig.expiringBound.@Tooltip[1]": "effect duration < expiring bound"`, the explanation might become clearer for users to understand if changes to ""expiring" < bound set here < "soon to expire"". 
- Also ""soon to expire" < bound set here < "won't expire soon"" 
 for `"text.autoconfig.compactstatuseffects.option.onlyNameConfig.soonToExpireBound.@Tooltip[1]": "expiring bound < effect duration < soon to expire bound"`